### PR TITLE
[WIP] Implement drmModeSetPlane

### DIFF
--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -2,7 +2,7 @@
 //!
 //! A plane is an object you can attach framebuffers to for use in displays.
 
-use control::{self, ResourceHandle, ResourceInfo};
+use control::{self, ResourceHandle, ResourceInfo, crtc, framebuffer};
 use result::*;
 use ffi;
 
@@ -71,6 +71,31 @@ impl ResourceInfo for Info {
     }
 
     fn handle(&self) -> Self::Handle { self.handle }
+}
+
+impl Handle {
+    pub fn set<T>(&self, device: &T, crtc: crtc::Handle, framebuffer: framebuffer::Handle, flags: u32, crtc_rect:((i32, i32), (u32, u32)), src_rect: ((u32, u32), (u32, u32))) -> Result<()>
+        where T: control::Device {
+
+        let mut raw : ffi::drm_mode_set_plane = Default::default();
+
+        raw.plane_id = self.as_raw();
+        raw.crtc_id = crtc.as_raw();
+        raw.fb_id = framebuffer.as_raw();
+        raw.flags = flags;
+        raw.crtc_x = (crtc_rect.0).0;
+        raw.crtc_y = (crtc_rect.0).1;
+        raw.crtc_w = (crtc_rect.1).0;
+        raw.crtc_h = (crtc_rect.1).1;
+        raw.src_x = (src_rect.0).0;
+        raw.src_y = (src_rect.0).1;
+        raw.src_w = (src_rect.1).0;
+        raw.src_h = (src_rect.1).1;
+
+        unsafe { ffi::ioctl_mode_setplane(device.as_raw_fd(), &mut raw)?; }
+
+        Ok(())
+    }
 }
 
 impl ::std::fmt::Debug for Handle {


### PR DESCRIPTION
A small function just to get a hang of it.

Some questions:

- Is the handle the correct place to implement `ioctl`s setting the state of a resource?
- Where can I find some docs on `drm_mode.h`? Related:
    - Where can I find out, what `flags` actually means? I think this should be a bitmap of some kind, so I would like to use `bitflags` for that instead of an `u32`
    - Where can I find out, what the return value means? I currently think it is a `bool`, but I just ignore it.
- Do you have some types / a place for common types in regards to graphics. I think something for points and rectangles, instead of this tuple madness I am currently doing, would be nice, but I was not sure, what your current approach on that is.