### PR TITLE
Cleanup set_plane call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,3 +89,12 @@ pub trait Device : AsRawFd {
     }
 }
 
+#[allow(non_camel_case_types)]
+pub type iPoint = (i32, i32);
+#[allow(non_camel_case_types)]
+pub type uPoint = (u32, u32);
+pub type Dimensions = (u32, u32);
+#[allow(non_camel_case_types)]
+pub type iRect = (iPoint, Dimensions);
+#[allow(non_camel_case_types)]
+pub type uRect = (uPoint, Dimensions);


### PR DESCRIPTION
Follow-up to #4.

- Move `set` out of the `Handle`
- Move `flags` into an actual `enum`
- Provide some type aliases for rectangles and points (feel free to move and rename them, if you don't like them)