### PR TITLE
Add crtc gamma control

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -6,4 +6,11 @@ error_chain! {
         Unix(nix::Error);
         Io(io::Error);
     }
+
+    errors {
+        InvalidGammaSize(set: usize, size: u32) {
+            description("Invalid Gamma Ramp Size")
+            display("Invalid Gamma Ramp Size: '{}', expected: '{}'", set, size)
+        }
+    }
 }


### PR DESCRIPTION
Added functions akin to `drmModeCrtcGetGamma` and `drmModeCrtcSetGamma` . I had to introduce a new error type to make a rusty-api, but now, I get some compiler warnings.
I have not yet used the `error-chain` crate (although it seems very nice), maybe I don't understand, how I should do it?

The warning is as follows:
```
warning: doc comment not used by rustdoc
  --> src/result.rs:3:1
   |
3  | / error_chain! {
4  | |     foreign_links {
5  | |         Unix(nix::Error);
6  | |     }
...  |
13 | |     }
14 | | }
   | |_^
   |
   = note: #[warn(unused_doc_comment)] on by default
   = note: this error originates in a macro outside of the current crate
```

Other then that, this is ready for merge in my eyes. What do you think @Slabity ? 