### PR TITLE
[WIP] drm_mode_add_fb2

### DIFF
--- a/drm-sys/src/fourcc.rs
+++ b/drm-sys/src/fourcc.rs
@@ -1,0 +1,75 @@
+macro_rules! __fourcc_code {
+    ($a:expr, $b:expr, $c:expr, $d:expr) => (
+        ($a as u32) | (($b as u32) << 8) | (($c as u32) << 16) | (($d as u32) << 24)
+    )
+}
+
+/* color index */
+pub const DRM_FORMAT_C8 	:u32 = __fourcc_code!('C', '8', ' ', ' '); /* [7:0] C */
+
+/* 8 bpp Red */
+pub const DRM_FORMAT_R8		:u32 = __fourcc_code!('R', '8', ' ', ' '); /* [7:0] R */
+
+/* 16 bpp RG */
+pub const DRM_FORMAT_GR88		:u32 = __fourcc_code!('G', 'R', '8', '8'); /* [15:0] G:R 8:8 little endian */
+
+/* 8 bpp RGB */
+pub const DRM_FORMAT_RGB332	:u32 = __fourcc_code!('R', 'G', 'B', '8'); /* [7:0] R:G:B 3:3:2 */
+pub const DRM_FORMAT_BGR233	:u32 = __fourcc_code!('B', 'G', 'R', '8'); /* [7:0] B:G:R 2:3:3 */
+
+/* 16 bpp RGB */
+pub const DRM_FORMAT_XRGB4444	:u32 = __fourcc_code!('X', 'R', '1', '2'); /* [15:0] x:R:G:B 4:4:4:4 little endian */
+pub const DRM_FORMAT_XBGR4444	:u32 = __fourcc_code!('X', 'B', '1', '2'); /* [15:0] x:B:G:R 4:4:4:4 little endian */
+pub const DRM_FORMAT_RGBX4444	:u32 = __fourcc_code!('R', 'X', '1', '2'); /* [15:0] R:G:B:x 4:4:4:4 little endian */
+pub const DRM_FORMAT_BGRX4444	:u32 = __fourcc_code!('B', 'X', '1', '2'); /* [15:0] B:G:R:x 4:4:4:4 little endian */
+
+pub const DRM_FORMAT_ARGB4444	:u32 = __fourcc_code!('A', 'R', '1', '2'); /* [15:0] A:R:G:B 4:4:4:4 little endian */
+pub const DRM_FORMAT_ABGR4444	:u32 = __fourcc_code!('A', 'B', '1', '2'); /* [15:0] A:B:G:R 4:4:4:4 little endian */
+pub const DRM_FORMAT_RGBA4444	:u32 = __fourcc_code!('R', 'A', '1', '2'); /* [15:0] R:G:B:A 4:4:4:4 little endian */
+pub const DRM_FORMAT_BGRA4444	:u32 = __fourcc_code!('B', 'A', '1', '2'); /* [15:0] B:G:R:A 4:4:4:4 little endian */
+
+pub const DRM_FORMAT_XRGB1555	:u32 = __fourcc_code!('X', 'R', '1', '5'); /* [15:0] x:R:G:B 1:5:5:5 little endian */
+pub const DRM_FORMAT_XBGR1555	:u32 = __fourcc_code!('X', 'B', '1', '5'); /* [15:0] x:B:G:R 1:5:5:5 little endian */
+pub const DRM_FORMAT_RGBX5551	:u32 = __fourcc_code!('R', 'X', '1', '5'); /* [15:0] R:G:B:x 5:5:5:1 little endian */
+pub const DRM_FORMAT_BGRX5551	:u32 = __fourcc_code!('B', 'X', '1', '5'); /* [15:0] B:G:R:x 5:5:5:1 little endian */
+
+pub const DRM_FORMAT_ARGB1555	:u32 = __fourcc_code!('A', 'R', '1', '5'); /* [15:0] A:R:G:B 1:5:5:5 little endian */
+pub const DRM_FORMAT_ABGR1555	:u32 = __fourcc_code!('A', 'B', '1', '5'); /* [15:0] A:B:G:R 1:5:5:5 little endian */
+pub const DRM_FORMAT_RGBA5551	:u32 = __fourcc_code!('R', 'A', '1', '5'); /* [15:0] R:G:B:A 5:5:5:1 little endian */
+pub const DRM_FORMAT_BGRA5551	:u32 = __fourcc_code!('B', 'A', '1', '5'); /* [15:0] B:G:R:A 5:5:5:1 little endian */
+
+pub const DRM_FORMAT_RGB565	:u32 = __fourcc_code!('R', 'G', '1', '6'); /* [15:0] R:G:B 5:6:5 little endian */
+pub const DRM_FORMAT_BGR565	:u32 = __fourcc_code!('B', 'G', '1', '6'); /* [15:0] B:G:R 5:6:5 little endian */
+
+/* 24 bpp RGB */
+pub const DRM_FORMAT_RGB888	:u32 = __fourcc_code!('R', 'G', '2', '4'); /* [23:0] R:G:B little endian */
+pub const DRM_FORMAT_BGR888	:u32 = __fourcc_code!('B', 'G', '2', '4'); /* [23:0] B:G:R little endian */
+
+/* 32 bpp RGB */
+pub const DRM_FORMAT_XRGB8888	:u32 = __fourcc_code!('X', 'R', '2', '4'); /* [31:0] x:R:G:B 8:8:8:8 little endian */
+pub const DRM_FORMAT_XBGR8888	:u32 = __fourcc_code!('X', 'B', '2', '4'); /* [31:0] x:B:G:R 8:8:8:8 little endian */
+pub const DRM_FORMAT_RGBX8888	:u32 = __fourcc_code!('R', 'X', '2', '4'); /* [31:0] R:G:B:x 8:8:8:8 little endian */
+pub const DRM_FORMAT_BGRX8888	:u32 = __fourcc_code!('B', 'X', '2', '4'); /* [31:0] B:G:R:x 8:8:8:8 little endian */
+
+pub const DRM_FORMAT_ARGB8888	:u32 = __fourcc_code!('A', 'R', '2', '4'); /* [31:0] A:R:G:B 8:8:8:8 little endian */
+pub const DRM_FORMAT_ABGR8888	:u32 = __fourcc_code!('A', 'B', '2', '4'); /* [31:0] A:B:G:R 8:8:8:8 little endian */
+pub const DRM_FORMAT_RGBA8888	:u32 = __fourcc_code!('R', 'A', '2', '4'); /* [31:0] R:G:B:A 8:8:8:8 little endian */
+pub const DRM_FORMAT_BGRA8888	:u32 = __fourcc_code!('B', 'A', '2', '4'); /* [31:0] B:G:R:A 8:8:8:8 little endian */
+
+pub const DRM_FORMAT_XRGB2101010	:u32 = __fourcc_code!('X', 'R', '3', '0'); /* [31:0] x:R:G:B 2:10:10:10 little endian */
+pub const DRM_FORMAT_XBGR2101010	:u32 = __fourcc_code!('X', 'B', '3', '0'); /* [31:0] x:B:G:R 2:10:10:10 little endian */
+pub const DRM_FORMAT_RGBX1010102	:u32 = __fourcc_code!('R', 'X', '3', '0'); /* [31:0] R:G:B:x 10:10:10:2 little endian */
+pub const DRM_FORMAT_BGRX1010102	:u32 = __fourcc_code!('B', 'X', '3', '0'); /* [31:0] B:G:R:x 10:10:10:2 little endian */
+
+pub const DRM_FORMAT_ARGB2101010	:u32 = __fourcc_code!('A', 'R', '3', '0'); /* [31:0] A:R:G:B 2:10:10:10 little endian */
+pub const DRM_FORMAT_ABGR2101010	:u32 = __fourcc_code!('A', 'B', '3', '0'); /* [31:0] A:B:G:R 2:10:10:10 little endian */
+pub const DRM_FORMAT_RGBA1010102	:u32 = __fourcc_code!('R', 'A', '3', '0'); /* [31:0] R:G:B:A 10:10:10:2 little endian */
+pub const DRM_FORMAT_BGRA1010102	:u32 = __fourcc_code!('B', 'A', '3', '0'); /* [31:0] B:G:R:A 10:10:10:2 little endian */
+
+/* packed YCbCr */
+pub const DRM_FORMAT_YUYV		:u32 = __fourcc_code!('Y', 'U', 'Y', 'V'); /* [31:0] Cr0:Y1:Cb0:Y0 8:8:8:8 little endian */
+pub const DRM_FORMAT_YVYU		:u32 = __fourcc_code!('Y', 'V', 'Y', 'U'); /* [31:0] Cb0:Y1:Cr0:Y0 8:8:8:8 little endian */
+pub const DRM_FORMAT_UYVY		:u32 = __fourcc_code!('U', 'Y', 'V', 'Y'); /* [31:0] Y1:Cr0:Y0:Cb0 8:8:8:8 little endian */
+pub const DRM_FORMAT_VYUY		:u32 = __fourcc_code!('V', 'Y', 'U', 'Y'); /* [31:0] Y1:Cb0:Y0:Cr0 8:8:8:8 little endian */
+
+pub const DRM_FORMAT_AYUV		:u32 = __fourcc_code!('A', 'Y', 'U', 'V'); /* [31:0] A:Y:Cb:Cr 8:8:8:8 little endian */

--- a/drm-sys/src/lib.rs
+++ b/drm-sys/src/lib.rs
@@ -11,3 +11,5 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
           target_os="linux",
           target_arch="x86_64"))]
 include!(concat!("platforms/linux/x86_64/bindings.rs"));
+
+pub mod fourcc;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,3 +1,5 @@
+use ffi::fourcc::*;
+
 /// The underlying handle for a buffer
 pub type RawId = u32;
 
@@ -18,12 +20,223 @@ impl Id {
 pub trait Buffer {
     /// The width and height of the buffer.
     fn size(&self) -> (u32, u32);
-    /// The depth of the buffer.
-    fn depth(&self) -> u8;
-    /// The number of bits per pixel.
-    fn bpp(&self) -> u8;
+    /// The format of the buffer.
+    fn format(&self) -> PixelFormat;
     /// The pitch of the buffer.
     fn pitch(&self) -> u32;
     /// The GEM handle of the buffer.
     fn handle(&self) -> Id;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PixelFormat {
+    C8,
+    R8,
+    GR88,
+
+    RGB332,
+    BGR233,
+
+    XRGB4444,
+    XBGR4444,
+    RGBX4444,
+    BGRX4444,
+
+    ARGB4444,
+    ABGR4444,
+    RGBA4444,
+    BGRA4444,
+
+    XRGB1555,
+    XBGR1555,
+    RGBX5551,
+    BGRX5551,
+
+    ARGB1555,
+    ABGR1555,
+    RGBA5551,
+    BGRA5551,
+
+    RGB565,
+    BGR565,
+
+    XRGB8888,
+    XBGR8888,
+    RGBX8888,
+    BGRX8888,
+
+    ARGB8888,
+    ABGR8888,
+    RGBA8888,
+    BGRA8888,
+
+    XRGB2101010,
+    XBGR2101010,
+    RGBX1010102,
+    BGRX1010102,
+
+    ARGB2101010,
+    ABGR2101010,
+    RGBA1010102,
+    BGRA1010102,
+
+    YUYV,
+    YVYU,
+    UYVY,
+    VYUY,
+
+    AYUV,
+}
+
+impl PixelFormat {
+    pub fn as_raw(&self) -> u32 {
+        use self::PixelFormat::*;
+        match *self {
+            C8 => DRM_FORMAT_C8,
+            R8 => DRM_FORMAT_R8,
+            GR88 => DRM_FORMAT_GR88,
+
+            RGB332 => DRM_FORMAT_RGB332,
+            BGR233 => DRM_FORMAT_BGR233,
+
+            XRGB4444 => DRM_FORMAT_XRGB4444,
+            XBGR4444 => DRM_FORMAT_XBGR4444,
+            RGBX4444 => DRM_FORMAT_RGBX4444,
+            BGRX4444 => DRM_FORMAT_BGRX4444,
+
+            ARGB4444 => DRM_FORMAT_ARGB4444,
+            ABGR4444 => DRM_FORMAT_ABGR4444,
+            RGBA4444 => DRM_FORMAT_RGBA4444,
+            BGRA4444 => DRM_FORMAT_BGRA4444,
+
+            XRGB1555 => DRM_FORMAT_XRGB1555,
+            XBGR1555 => DRM_FORMAT_XBGR1555,
+            RGBX5551 => DRM_FORMAT_RGBX5551,
+            BGRX5551 => DRM_FORMAT_BGRX5551,
+
+            ARGB1555 => DRM_FORMAT_ARGB1555,
+            ABGR1555 => DRM_FORMAT_ABGR1555,
+            RGBA5551 => DRM_FORMAT_RGBA4444,
+            BGRA5551 => DRM_FORMAT_RGBA5551,
+
+            RGB565 => DRM_FORMAT_RGB565,
+            BGR565 => DRM_FORMAT_BGR565,
+
+            XRGB8888 => DRM_FORMAT_XRGB8888,
+            XBGR8888 => DRM_FORMAT_XBGR8888,
+            RGBX8888 => DRM_FORMAT_RGBX8888,
+            BGRX8888 => DRM_FORMAT_BGRX8888,
+
+            ARGB8888 => DRM_FORMAT_ARGB8888,
+            ABGR8888 => DRM_FORMAT_ABGR8888,
+            RGBA8888 => DRM_FORMAT_RGBA8888,
+            BGRA8888 => DRM_FORMAT_BGRA8888,
+
+            XRGB2101010 => DRM_FORMAT_XRGB2101010,
+            XBGR2101010 => DRM_FORMAT_XBGR2101010,
+            RGBX1010102 => DRM_FORMAT_RGBX1010102,
+            BGRX1010102 => DRM_FORMAT_BGRX1010102,
+
+            ARGB2101010 => DRM_FORMAT_ARGB2101010,
+            ABGR2101010 => DRM_FORMAT_ABGR2101010,
+            RGBA1010102 => DRM_FORMAT_RGBA1010102,
+            BGRA1010102 => DRM_FORMAT_BGRA1010102,
+
+            YUYV => DRM_FORMAT_YUYV,
+            YVYU => DRM_FORMAT_YVYU,
+            UYVY => DRM_FORMAT_UYVY,
+            VYUY => DRM_FORMAT_VYUY,
+
+            AYUV => DRM_FORMAT_AYUV,
+        }
+    }
+
+    pub fn depth(&self) -> Option<u8> {
+        use self::PixelFormat::*;
+        match *self {
+            XRGB1555 => Some(15),
+            RGB565 => Some(16),
+            XRGB8888 => Some(24),
+            ARGB8888 => Some(32),
+            XRGB2101010 => Some(30),
+            _ => None,
+        }
+    }
+
+    pub fn bpp(&self) -> Option<u8> {
+        use self::PixelFormat::*;
+        match *self {
+            XRGB1555 => Some(16),
+            RGB565 => Some(16),
+            XRGB8888 => Some(32),
+            ARGB8888 => Some(32),
+            XRGB2101010 => Some(32),
+            _ => None,
+        }
+    }
+
+    pub fn from_raw(raw: u32) -> Option<PixelFormat> {
+        use self::PixelFormat::*;
+
+        match raw {
+            x if x == DRM_FORMAT_C8 as u32 => Some(C8),
+            x if x == DRM_FORMAT_R8 as u32 => Some(R8),
+            x if x == DRM_FORMAT_GR88 as u32 => Some(GR88),
+
+            x if x == DRM_FORMAT_RGB332 as u32 => Some(RGB332),
+            x if x == DRM_FORMAT_BGR233 as u32 => Some(BGR233),
+
+            x if x == DRM_FORMAT_XRGB4444 as u32 => Some(XRGB4444),
+            x if x == DRM_FORMAT_XBGR4444 as u32 => Some(XBGR4444),
+            x if x == DRM_FORMAT_RGBX4444 as u32 => Some(RGBX4444),
+            x if x == DRM_FORMAT_BGRX4444 as u32 => Some(BGRX4444),
+
+            x if x == DRM_FORMAT_ARGB4444 as u32 => Some(ARGB4444),
+            x if x == DRM_FORMAT_ABGR4444 as u32 => Some(ABGR4444),
+            x if x == DRM_FORMAT_RGBA4444 as u32 => Some(RGBA4444),
+            x if x == DRM_FORMAT_BGRA4444 as u32 => Some(BGRA4444),
+
+            x if x == DRM_FORMAT_XRGB1555 as u32 => Some(XRGB1555),
+            x if x == DRM_FORMAT_XBGR1555 as u32 => Some(XBGR1555),
+            x if x == DRM_FORMAT_RGBX5551 as u32 => Some(RGBX5551),
+            x if x == DRM_FORMAT_BGRX5551 as u32 => Some(BGRX5551),
+
+            x if x == DRM_FORMAT_ARGB1555 as u32 => Some(ARGB1555),
+            x if x == DRM_FORMAT_ABGR1555 as u32 => Some(ABGR1555),
+            x if x == DRM_FORMAT_RGBA5551 as u32 => Some(RGBA5551),
+            x if x == DRM_FORMAT_BGRA5551 as u32 => Some(BGRA5551),
+
+            x if x == DRM_FORMAT_RGB565 as u32 => Some(RGB565),
+            x if x == DRM_FORMAT_BGR565 as u32 => Some(BGR565),
+
+            x if x == DRM_FORMAT_XRGB8888 as u32 => Some(XRGB8888),
+            x if x == DRM_FORMAT_XBGR8888 as u32 => Some(XBGR8888),
+            x if x == DRM_FORMAT_RGBX8888 as u32 => Some(RGBX8888),
+            x if x == DRM_FORMAT_BGRX8888 as u32 => Some(BGRX8888),
+
+            x if x == DRM_FORMAT_ARGB8888 as u32 => Some(ARGB8888),
+            x if x == DRM_FORMAT_ABGR8888 as u32 => Some(ABGR8888),
+            x if x == DRM_FORMAT_RGBA8888 as u32 => Some(RGBA8888),
+            x if x == DRM_FORMAT_BGRA8888 as u32 => Some(BGRA8888),
+
+            x if x == DRM_FORMAT_XRGB2101010 as u32 => Some(XRGB2101010),
+            x if x == DRM_FORMAT_XBGR2101010 as u32 => Some(XBGR2101010),
+            x if x == DRM_FORMAT_RGBX1010102 as u32 => Some(RGBX1010102),
+            x if x == DRM_FORMAT_BGRX1010102 as u32 => Some(BGRX1010102),
+
+            x if x == DRM_FORMAT_ARGB2101010 as u32 => Some(ARGB2101010),
+            x if x == DRM_FORMAT_ABGR2101010 as u32 => Some(ABGR2101010),
+            x if x == DRM_FORMAT_RGBA1010102 as u32 => Some(RGBA1010102),
+            x if x == DRM_FORMAT_BGRA1010102 as u32 => Some(BGRA1010102),
+
+            x if x == DRM_FORMAT_YUYV as u32 => Some(YUYV),
+            x if x == DRM_FORMAT_YVYU as u32 => Some(YVYU),
+            x if x == DRM_FORMAT_UYVY as u32 => Some(UYVY),
+            x if x == DRM_FORMAT_VYUY as u32 => Some(VYUY),
+
+            x if x == DRM_FORMAT_AYUV as u32 => Some(AYUV),
+
+            _ => None
+        }
+    }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -4,4 +4,11 @@ error_chain! {
     foreign_links {
         Unix(nix::Error);
     }
+
+    errors {
+        UnsupportedPixelFormat {
+            description("PixelFormat is unsupported by operation")
+            display("The provided PixelFormat is not supported by the operation")
+        }
+    }
 }


### PR DESCRIPTION
This is quite a though one, that why I am presenting this PR so unpolished and complete.

This tries to use `drm_mode_add_fb2`, when supported by the underlying system and falls back to the legacy ioctl otherwise.

To do this, it introduces a `PixelFormat`, which can be converted back to `depth` and `bpp` if supported. (Note that this is a superset. There is no valid depth and bpp combination, that is not represented by a valid  pixel format for `drm_mode_add_fb2` as far as I know.)

The pixel format values are coming from `libdrm/drm_fourcc.h`, which is why it has that weird name in the sys-crate, to follow the libdrm api closely. Bindgen fails on that one and I already had coded an [almost identical file](https://github.com/Drakulix/gbm.rs/blob/master/src/lib.rs#L67) for my `gbm` crate (which I still need to move here at some point), so I just did use that, it closely resembles the original file. (libgbm and libdrm share the possible formats and their representation.)

This conversion to depth and bpp is necessary for creating dumb buffers and for falling back to the old ioctl and throws an error if not supported for the given pixel format.

This gives a nice API (in my opinion), but creates a range of problems:
- The Framebuffer `Info` struct cannot contain the format, because there is no `drm_mode_get_fb2`-ioctl to fixup `load_from_device`. (Google actually wants to patch this, but this means if `drm_mode_add_fb2` is available there will still be the possibility that `drm_mode_get_fb2` is not available on older kernel versions, so this only makes matters more complicated.)
- The Framebuffer `Info` struct might even contain invalid information. Some pixel formats exclusive to `drm_mode_add_fb2` can cause wrong depth and bpp values.
- Adding multiple buffers, flags and modifiers will make the function signature more complicated and introduce more errors, that can happen. E.g. if multiple buffers are set, but we need to fallback, which cannot be done with multiple buffers, we need to catch that and error. At least this is possible, but makes the fallback rather useless, as it only works in very simple cases and breaks almost immediately for any other case.
- Fixing this by creating a new function like `create2` that uses the new ioctl exclusively and keep `create` is also not optimal. It can still throw an `UnsupportedPixelFormat` error, which is more difficult then the old api. But we do not want to introduce multiple `Buffer` traits to restore the old api (or do we?). 

I do view the current solution as the best, I can think of. But I am not completely happy with it and would like to have some feedback on this @Slabity. Thanks :)