### PR TITLE
Feature/page flip

### DIFF
--- a/drm-sys/src/platforms/linux/x86_64/bindings.rs
+++ b/drm-sys/src/platforms/linux/x86_64/bindings.rs
@@ -4071,7 +4071,7 @@ pub struct drm_event_vblank {
     pub tv_sec: __u32,
     pub tv_usec: __u32,
     pub sequence: __u32,
-    pub reserved: __u32,
+    pub crtc_id: __u32, /* 0 on older kernels that do not support this */
 }
 #[test]
 fn bindgen_test_layout_drm_event_vblank() {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,9 @@
+use std::io;
 use nix;
 
 error_chain! {
     foreign_links {
         Unix(nix::Error);
+        Io(io::Error);
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,12 @@
 #![feature(drop_types_in_const)]
 
 extern crate drm;
+extern crate nix;
 
 use std::fs::{OpenOptions, File};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Mutex, MutexGuard, Once, ONCE_INIT};
+use std::time::{Duration, Instant};
 
 use drm::Device as BasicDevice;
 use drm::control::Device as ControlDevice;
@@ -107,7 +109,7 @@ fn load_resources() {
 #[test]
 fn legacy_modeset() {
     // Can't run with other modesetting tests.
-    let guard = wait_for_lock();
+    let _guard = wait_for_lock();
 
     let card = Card::open_control();
 
@@ -132,9 +134,11 @@ fn legacy_modeset() {
         .expect("Could not create dumb buffer");
 
     // Map it and grey it out.
-    let mut map = db.map(&card).expect("Could not map dumbbuffer");
-    for mut b in map.as_mut() {
-        *b = 128;
+    {
+        let mut map = db.map(&card).expect("Could not map dumbbuffer");
+        for mut b in map.as_mut() {
+            *b = 128;
+        }
     }
 
     // Create an FB:
@@ -151,4 +155,120 @@ fn legacy_modeset() {
 
     let five_seconds = ::std::time::Duration::from_millis(5000);
     ::std::thread::sleep(five_seconds);
+
+    framebuffer::destroy(&card, fbinfo.handle()).unwrap();
+    db.destroy(&card).unwrap();
+}
+
+#[test]
+fn vblank_modeset() {
+    use std::any::Any;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use nix::sys::{time, select};
+    use nix::sys::time::TimeValLike;
+
+    let cleanup = AtomicBool::new(false);
+
+    // Can't run with other modesetting tests.
+    let _guard = wait_for_lock();
+
+    let card = Card::open_control();
+
+    // Load the information.
+    let res = card.resource_handles().expect("Could not load normal resource ids.");
+    let coninfo: Vec<connector::Info> = load_information(&card, res.connectors());
+    let crtcinfo: Vec<crtc::Info> = load_information(&card, res.crtcs());
+
+    // Filter each connector until we find one that's connected.
+    let con = coninfo.iter().filter(| &i | {
+        i.connection_state() == connector::State::Connected
+    }).next().expect("No connected connectors");
+
+    // Get the first (usually best) mode
+    let &mode = con.modes().iter().next().expect("No modes found on connector");
+
+    // Find a crtc and FB
+    let crtc = crtcinfo.iter().next().expect("No crtcs found");
+
+    // Create a DB
+    let db1 = dumbbuffer::DumbBuffer::create_from_device(&card, (1920, 1080), 32)
+        .expect("Could not create dumb buffer");
+    let db2 = dumbbuffer::DumbBuffer::create_from_device(&card, (1920, 1080), 32)
+        .expect("Could not create dumb buffer");
+
+    // Map them and set one white and one black.
+    {
+        let mut map1 = db1.map(&card).expect("Could not map dumbbuffer");
+        for mut b1 in map1.as_mut() {
+            *b1 = 255;
+        }
+        let mut map2 = db2.map(&card).expect("Could not map dumbbuffer");
+        for mut b2 in map2.as_mut() {
+            *b2 = 0;
+        }
+    }
+
+    // Create FBs:
+    let fb_infos =  [
+                        framebuffer::create(&card, &db1)
+                            .expect("Could not create FB1"),
+                        framebuffer::create(&card, &db2)
+                            .expect("Could not create FB2")
+                    ];
+
+    println!("{:#?}", mode);
+    println!("{:#?}", fb_infos);
+    println!("{:#?}", db1);
+    println!("{:#?}", db2);
+
+    // Set the crtc
+    crtc::set(&card, crtc.handle(), fb_infos[0].handle(), &[con.handle()], (0, 0), Some(mode))
+        .expect("Could not set CRTC");
+    crtc::page_flip(&card, crtc.handle(), fb_infos[1].handle(), &[crtc::PageFlipFlags::PageFlipEvent], None::<Box<()>>).expect("Failed to queue Page Flip");
+
+    struct PageFlipHandler<'a> {
+        index: usize,
+        cleanup: &'a AtomicBool,
+        crtc: crtc::Handle,
+        fb_infos: [framebuffer::Info; 2],
+    }
+
+    impl<'a, T: ControlDevice> crtc::PageFlipHandler<T> for PageFlipHandler<'a> {
+        fn handle_event(&mut self, device: &T, _: u32, _: Duration, userdata: Box<Any>) {
+            if !self.cleanup.load(Ordering::Acquire) {
+                crtc::page_flip(device, self.crtc, self.fb_infos[self.index].handle(), &[crtc::PageFlipFlags::PageFlipEvent], userdata).expect("Failed to queue Page Flip");
+                self.index = (self.index + 1) % 2;
+            }
+        }
+    }
+
+    let mut handler = PageFlipHandler {
+        index: 0,
+        cleanup: &cleanup,
+        crtc: crtc.handle(),
+        fb_infos: fb_infos,
+    };
+
+    let start = Instant::now();
+    while Instant::now().duration_since(start) < Duration::new(5, 0) {
+        let mut readfds = select::FdSet::new();
+        readfds.insert(card.as_raw_fd());
+        match select::select(card.as_raw_fd() + 1, Some(&mut readfds), None, None, Some(&mut time::TimeVal::seconds(5))) {
+            Ok(1) => crtc::handle_event(&card, 2, None::<&mut ()>, Some(&mut handler), None::<&mut ()>).expect("Unable to handle event"),
+            Ok(0) => break,
+            Ok(_) => unreachable!(),
+            Err(_) => break,
+        }
+    }
+
+    cleanup.store(true, Ordering::Release);
+    crtc::handle_event(&card, 2, None::<&mut ()>, Some(&mut handler), None::<&mut ()>).expect("Unable to handle event");
+
+    let mut fbs = fb_infos.to_vec();
+    for fb in fbs.drain(..) {
+        framebuffer::destroy(&card, fb.handle()).unwrap();
+    }
+
+    db1.destroy(&card).unwrap();
+    db2.destroy(&card).unwrap();
 }


### PR DESCRIPTION
Depends on #9 for cleanup (necessary for chaining the tests reliably).

Implements page flipping and adds a (rather obnoxious looking) test that uses it.
Also implements dump buffer destruction for cleanup.