### PR TITLE
Remove associated_consts feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(associated_consts)]
-
 #[macro_use]
 extern crate nix;
 extern crate drm_sys;


### PR DESCRIPTION
Associated consts is stabilized in the current form used by drm-rs, already works in beta and will be in rust stable 1.20. (see https://github.com/rust-lang/rust/issues/29646#issuecomment-325419397)

Using the feature flag prevents compilation on beta, as the feature flag is generally not allowed on stable and beta channels even if the feature in question is already stabilized.


tl;dr This fixes compilation on current beta and upcoming stable 1.20