### PR TITLE
Feature/encoder

### DIFF
--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -18,7 +18,7 @@ use result::*;
 /// [`ResourceHandle`]: ../ResourceHandle.t.html
 /// [`connector::Info`]: Info.t.html
 /// [`ResourceHandles::connectors`]: ../ResourceHandles.t.html#method.connectors
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for a connector.

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -89,6 +89,11 @@ impl Info {
     pub fn modes<'a>(&'a self) -> &'a [control::Mode] {
         &self.modes
     }
+
+    /// Returns a list containing each supported [`encoder::Handle`].
+    pub fn encoders<'a>(&'a self) -> &'a [control::encoder::Handle] {
+        &self.encoders
+    }
 }
 
 impl ResourceHandle for Handle {

--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`crtc::Info`]: Info.t.html
 /// [`ResourceIds::crtcs`]: ResourceIds.t.html#method.crtcs
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for a CRTC.

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -18,7 +18,7 @@ use ffi;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`encoder::Info`]: Info.t.html
 /// [`ResourceHandles::encoders`]: ResourceHandles.t.html#method.encoders
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for an encoder.

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -19,7 +19,7 @@ use ffi;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`framebuffer::Info`]: Info.t.html
 /// [`ResourceIds::framebuffers`]: ResourceIds.t.html#method.framebuffers
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,6 +1,7 @@
 use result::*;
 use ffi;
 use std::ffi::CStr;
+use std::hash::Hash;
 pub mod connector;
 pub mod encoder;
 pub mod crtc;
@@ -71,7 +72,7 @@ pub trait Device : Sized + super::Device {
 /// provide some sort of handle that we can use to refer to them. Almost all
 /// operations performed on a `Device` that use an object or resource require
 /// making requests using a handle.
-pub trait ResourceHandle: Eq + Copy {
+pub trait ResourceHandle: Eq + Copy + Hash {
     /// Create this handle from its raw part.
     fn from_raw(RawHandle) -> Self;
 

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -18,7 +18,7 @@ use ::{iRect, uRect};
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`plane::Info`]: Info.t.html
 /// [`PlaneResourceHandles::planes`]: PlaneResourceHandles.t.html#method.planes
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 /// The underlying value type of a property.
 pub type RawValue = u64;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// A `ResourceHandle` to a property.
 pub struct Handle(control::RawHandle);
 


### PR DESCRIPTION
I need functionality to check which encoders are supported by a crtc and which connectors support which encoders. (see https://github.com/Smithay/smithay/pull/34/commits/75601d8f6a0633fd9e5d073d80c44979dc098047)

Also there seems to be no reason not to let the `Handle`s implement `std::hash::Hash`, which is really useful when filtering for encoders (as seen in the commit above), so that was added as well.

I have seen you already had different plant with your `CrtcListFilter`, but I don't understand where you were going with it and this was quick and easy to implement. If you wish for some other solution, please tell me and I will adjust this PR until it fits your vision and my needs.

https://github.com/Smithay/smithay/pull/34 depends on this PR, so just like with #12, I would :heart: a quick release, if possible.

