### PR TITLE
Add a lot of docs

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,13 +4,16 @@ use ffi::fourcc::*;
 pub type RawId = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// GEM handle of a buffer
 pub struct Id(RawId);
 
 impl Id {
+    /// Convert into a GEM handle from the raw type
     pub fn from_raw(raw: RawId) -> Self {
         Id(raw)
     }
 
+    /// Convert into the raw type
     pub fn as_raw(&self) -> RawId {
         self.0
     }
@@ -29,6 +32,8 @@ pub trait Buffer {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+/// Possible pixel formats of a buffer
 pub enum PixelFormat {
     C8,
     R8,
@@ -89,6 +94,7 @@ pub enum PixelFormat {
 }
 
 impl PixelFormat {
+    /// Convert into the raw fourcc code
     pub fn as_raw(&self) -> u32 {
         use self::PixelFormat::*;
         match *self {
@@ -151,6 +157,7 @@ impl PixelFormat {
         }
     }
 
+    /// Depth value of the format
     pub fn depth(&self) -> Option<u8> {
         use self::PixelFormat::*;
         match *self {
@@ -163,6 +170,7 @@ impl PixelFormat {
         }
     }
 
+    /// Bytes per pixel of the used format
     pub fn bpp(&self) -> Option<u8> {
         use self::PixelFormat::*;
         match *self {
@@ -175,6 +183,7 @@ impl PixelFormat {
         }
     }
 
+    /// Try to parse format from raw fourcc code
     pub fn from_raw(raw: u32) -> Option<PixelFormat> {
         use self::PixelFormat::*;
 

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -18,7 +18,7 @@ use result::*;
 /// [`ResourceHandle`]: ../ResourceHandle.t.html
 /// [`connector::Info`]: Info.t.html
 /// [`ResourceHandles::connectors`]: ../ResourceHandles.t.html#method.connectors
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for a connector.

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -89,6 +89,11 @@ impl Info {
     pub fn modes<'a>(&'a self) -> &'a [control::Mode] {
         &self.modes
     }
+
+    /// Returns a list containing each supported [`encoder::Handle`].
+    pub fn encoders<'a>(&'a self) -> &'a [control::encoder::Handle] {
+        &self.encoders
+    }
 }
 
 impl ResourceHandle for Handle {

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -39,6 +39,7 @@ pub struct Info {
 
 /// The physical type of connector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Type {
     Unknown,
     VGA,
@@ -62,6 +63,7 @@ pub enum Type {
 
 /// The connection state of a connector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum State {
     Connected,
     Disconnected,

--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`crtc::Info`]: Info.t.html
 /// [`ResourceIds::crtcs`]: ResourceIds.t.html#method.crtcs
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for a CRTC.

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -1,9 +1,16 @@
+//!
+//! # DumbBuffer
+//!
+//! Memory-supported, slow, but easy & cross-platform buffer implementation
+//!
+
 use ffi;
 use result::*;
 use control;
 use buffer;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// Slow, but generic `Buffer` implementation
 pub struct DumbBuffer {
     size: (u32, u32),
     length: usize,
@@ -12,12 +19,14 @@ pub struct DumbBuffer {
     handle: buffer::Id
 }
 
+/// Mapping of a dumbbuffer
 pub struct DumbMapping<'a> {
     _phantom: ::std::marker::PhantomData<&'a ()>,
     map: &'a mut [u8]
 }
 
 impl DumbBuffer {
+    /// Create a new dumb buffer with a given size and pixel format
     pub fn create_from_device<T>(device: &T, size: (u32, u32), format: buffer::PixelFormat)
                              -> Result<Self>
         where T: control::Device {
@@ -42,6 +51,7 @@ impl DumbBuffer {
         Ok(dumb)
     }
 
+    /// Free the memory resources of a dumb buffer
     pub fn destroy<T>(self, device: &T) -> Result<()>
         where T: control::Device {
 
@@ -55,9 +65,10 @@ impl DumbBuffer {
         Ok(())
     }
 
-    pub fn map<'a, T>(&'a self, device: &T) -> Result<DumbMapping<'a>>
+    /// Map the buffer for access
+    pub fn map<'a, T>(&'a mut self, device: &T) -> Result<DumbMapping<'a>>
         where T: control::Device {
-
+        
         let mut raw: ffi::drm_mode_map_dumb = Default::default();
         raw.handle = self.handle.as_raw();
 

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -18,7 +18,7 @@ use ffi;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`encoder::Info`]: Info.t.html
 /// [`ResourceHandles::encoders`]: ResourceHandles.t.html#method.encoders
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 /// A [`ResourceInfo`] for an encoder.

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -35,6 +35,7 @@ pub struct Info {
 
 /// The type of encoder.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Type {
     None,
     DAC,

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -19,7 +19,7 @@ use ffi;
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`framebuffer::Info`]: Info.t.html
 /// [`ResourceIds::framebuffers`]: ResourceIds.t.html#method.framebuffers
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -1,4 +1,4 @@
-//! # CFramebuffer
+//! # Framebuffer
 //!
 //! A framebuffer is pixel data that can be attached to a plane.
 
@@ -22,6 +22,9 @@ use ffi;
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
+/// A [`ResourceInfo`] for a framebuffer.
+///
+/// [`ResourceInfo`]: ResourceInfo.t.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Info {
     handle: Handle,
@@ -127,8 +130,10 @@ pub fn create<T, U>(device: &T, buffer: &U) -> Result<Info>
     Ok(framebuffer)
 }
 
+/// Rect inside the area of a framebuffer
 pub type ClipRect = ffi::drm_clip_rect;
 
+/// Mark areas of a framebuffer dirty
 pub fn mark_dirty<T>(device: &T, fb: Handle, clips: &[ClipRect]) -> Result<()>
     where T: control::Device {
 
@@ -145,6 +150,7 @@ pub fn mark_dirty<T>(device: &T, fb: Handle, clips: &[ClipRect]) -> Result<()>
     Ok(())
 }
 
+/// Destroy a framebuffer
 pub fn destroy<T>(device: &T, fb: Handle) -> Result<()>
     where T: control::Device {
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,6 +1,7 @@
 use result::*;
 use ffi;
 use std::ffi::CStr;
+use std::hash::Hash;
 pub mod connector;
 pub mod encoder;
 pub mod crtc;
@@ -71,7 +72,7 @@ pub trait Device : Sized + super::Device {
 /// provide some sort of handle that we can use to refer to them. Almost all
 /// operations performed on a `Device` that use an object or resource require
 /// making requests using a handle.
-pub trait ResourceHandle: Eq + Copy {
+pub trait ResourceHandle: Eq + Copy + Hash {
     /// Create this handle from its raw part.
     fn from_raw(RawHandle) -> Self;
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -218,6 +218,7 @@ impl PlaneResourceHandles {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Type {
     Connector,
     Encoder,

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -75,11 +75,13 @@ impl ResourceInfo for Info {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
 pub enum PresentFlag {
     TopField = (0 << 1),
     BottomField = (1 << 1),
 }
 
+/// Attaches a framebuffer to a CRTC's plane for hardware-composing
 pub fn set<T>(plane: Handle, device: &T, crtc: crtc::Handle, framebuffer: framebuffer::Handle, flags: PresentFlag, crtc_rect: iRect, src_rect: uRect) -> Result<()>
     where T: control::Device
 {

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -18,7 +18,7 @@ use ::{iRect, uRect};
 /// [`ResourceHandle`]: ResourceHandle.t.html
 /// [`plane::Info`]: Info.t.html
 /// [`PlaneResourceHandles::planes`]: PlaneResourceHandles.t.html#method.planes
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(control::RawHandle);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 /// The underlying value type of a property.
 pub type RawValue = u64;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// A `ResourceHandle` to a property.
 pub struct Handle(control::RawHandle);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,9 +1,14 @@
+//!
+//! Foreign function interface
+//!
+
 #![allow(dead_code)]
+#![allow(missing_docs)]
 
 use nix::libc;
 pub use drm_sys::*;
 
-// The type to be used as an buffer.
+/// The type to be used as an ffi buffer.
 pub type Buffer<T> = Vec<T>;
 
 // Creates a buffer to be modified by an FFI function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,118 @@
+//!
+//! # drm-rs
+//!
+//! drm-rs
+//!
+//! This library is a safe interface to the Direct Rendering Manager API found on various operating systems.
+//!
+//! This library is currently a work in progress.
+//!
+//! ## Usage
+//!
+//! The user is expected to implement their own functionality for opening and
+//! accessing the file descriptor of the device. Here we create a small wrapper
+//! around `File` and implement `AsRawFd`, `drm::Device`, and
+//! `drm::control::Device`:
+//!
+//! ```rust,ignore
+//! extern crate drm;
+//!
+//! use std::fs::{OpenOptions, File};
+//! use std::os::unix::io::{AsRawFd, RawFd};
+//!
+//! use drm::Device as BasicDevice;
+//! use drm::control::Device as ControlDevice;
+//!
+//! // The drm crate does not provide a method of opening the device.
+//! // It is expected to be implemented by the user.
+//! struct Card(File);
+//!
+//! // Required to implement drm::Device
+//! impl AsRawFd for Card {
+//!     fn as_raw_fd(&self) -> RawFd { self.0.as_raw_fd() }
+//! }
+//!
+//! // Required to implement drm::control::Device
+//! impl BasicDevice for Card { }
+//!
+//! // Allows modesetting functionality to be performed.
+//! impl ControlDevice for Card { }
+//!
+//! ```
+//!
+//! Assuming the program used the above wrapper, the user now opens the card:
+//!
+//! ```rust,ignore
+//! // Open the device (usually located at /dev/dri/*) with rw access.
+//! let mut options = OpenOptions::new();
+//! options.read(true);
+//! options.write(true);
+//! let file = options.open("/dev/dri/card0");
+//! let card = Card(file);
+//! ```
+//!
+//! Now we can check out what resources are available:
+//!
+//! ```rust,ignore
+//! // Get a set of all modesetting resource handles (excluding planes):
+//! let res_handles = card.resource_handles().unwrap();
+//!
+//! // Print all connector information
+//! for &con in res_handles.connectors() {
+//!     let info = card.resource_info(con).unwrap();
+//!
+//!     println!("{:#?}")
+//! }
+//!
+//! // Print all CRTC information
+//! for &crtc in res_handles.crtcs() {
+//!     let info = card.resource_info(crtc).unwrap();
+//!
+//!     println!("{:#?}")
+//! }
+//! ```
+//!
+//! You'll also want to find a suitable mode:
+//!
+//! ```rust,ignore
+//! // Assuming we found a good connector and loaded the info into `connector_info`
+//! let &mode = connector_info.modes().iter(); // Search until you find one you want.
+//! ```
+//!
+//! Once you find a suitable connector and CRTC, it's time to create a framebuffer.
+//! Here we use a simple dumbbuffer as the backend:'
+//!
+//! ```rust,ignore
+//! // Create a DB of size 1920x1080
+//! let db = dumbbuffer::DumbBuffer::create_from_device(&card, (1920, 1080), 32)
+//!     .expect("Could not create dumb buffer");
+//!
+//! // Map it and grey it out.
+//! let mut map = db.map(&card).expect("Could not map dumbbuffer");
+//! for mut b in map.as_mut() {
+//!     *b = 128; // Grey
+//! }
+//!
+//! let fb_info = framebuffer::Info::create_from_buffer(&card, &db)
+//! let fb_handle = fb_info.handle();
+//! ```
+//!
+//! Now we can apply the framebuffer onto the CRTC's internal plane, and connect it
+//! to a connector with the proper mode:
+//!
+//! ```rust,ignore
+//! // Assuming `crtc` is a crtc handle and `con` is a connector handle
+//! crtc.set_on_device(&card, fb_handle, &[con], (0, 0), Some(mode))
+//!     .expect("Could not set Crtc");
+//! ```
+//!
+//! The contents of the dumb buffer will now appear onto the screen.
+
+#![warn(missing_docs)]
+
+extern crate drm_sys;
 #[macro_use]
 extern crate nix;
-extern crate drm_sys;
 
 #[macro_use]
 extern crate error_chain;
@@ -28,8 +140,11 @@ pub struct AuthToken(u32);
 /// These can be used to tell the DRM device what capabilities the process can
 /// use.
 pub enum ClientCapability {
+    /// Stereoscopic 3D Support
     Stereo3D = ffi::DRM_CLIENT_CAP_STEREO_3D as isize,
+    /// Universal plane access and api
     UniversalPlanes = ffi::DRM_CLIENT_CAP_UNIVERSAL_PLANES as isize,
+    /// Atomic modesetting support
     Atomic = ffi::DRM_CLIENT_CAP_ATOMIC as isize
 }
 
@@ -90,11 +205,16 @@ pub trait Device : AsRawFd {
 }
 
 #[allow(non_camel_case_types)]
+/// Signed point
 pub type iPoint = (i32, i32);
 #[allow(non_camel_case_types)]
+/// Unsigned point
 pub type uPoint = (u32, u32);
+/// Dimensions (width, height)
 pub type Dimensions = (u32, u32);
 #[allow(non_camel_case_types)]
+/// Rectangle with a signed upper left corner
 pub type iRect = (iPoint, Dimensions);
 #[allow(non_camel_case_types)]
+/// Rectangle with an unsigned upper left corner
 pub type uRect = (uPoint, Dimensions);

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,18 +1,24 @@
+//!
+//! Error types
+//!
+
 use std::io;
 use nix;
 
 error_chain! {
     foreign_links {
-        Unix(nix::Error);
-        Io(io::Error);
+        Unix(nix::Error) #[doc = "Unix error"];
+        Io(io::Error) #[doc = "I/O error"];
     }
 
     errors {
+        #[doc = "Size of the given gamma ramp does not match the device"]
         InvalidGammaSize(set: usize, size: u32) {
             description("Invalid Gamma Ramp Size")
             display("Invalid Gamma Ramp Size: '{}', expected: '{}'", set, size)
         }
 
+        #[doc = "Pixel format is not supported by the operation/device"]
         UnsupportedPixelFormat {
             description("PixelFormat is unsupported by operation")
             display("The provided PixelFormat is not supported by the operation")


### PR DESCRIPTION
Alright, so I did a very poor job at documentation any of my changes so I decided to start just documenting the whole crate.

Of course this is quite difficult with a lot of the original drm api not being well documentated and me having not a good idea of how everything works, but it is a start.

I will maybe continue to work on this PR and also would welcome anyone to contribute, but I am also happy with a merge in this state, I can always follow up with more.

Also feedback is very welcome.

Some *API changes* creeped into this, if I should move these to a separated PR @Slabity just tell me, they are really small:

- `set_cursor` and `set_cursor2` now take a `Buffer` reference instead of a separate `Buffer::Id` and `dimensions`.
- `crtc::page_flip` does not take a version anymore as this is not necessary at all.
- `DumpBuffer::map` now takes a mutable reference, as otherwise on some drivers you can get multiple mutable references to the same memory area.